### PR TITLE
Change mosquitto: allow_connections_from to 0.0.0.0/0

### DIFF
--- a/host_vars/vagrant.yml
+++ b/host_vars/vagrant.yml
@@ -4,7 +4,7 @@ iptables:
 
 mosquitto:
   allow_connections_from:
-    - 0.0.0.0
+    - 0.0.0.0/0
 
 postgresql:
   databases:


### PR DESCRIPTION
Hi,
First, thank you for making this great setup project :)
I tried it and couldn't connect to the MQTT broker, and found out that the iptables rules for the MQTT port (1883) had source address field to 0.0.0.0 instead of 0.0.0.0/0 (everywhere). This lead to packet drops when attempting to connect to the MQTT broker.

This small change aims to fix that ! 