### PR TITLE
Fix vagrant.yml TLS configuration for Mosquitto

### DIFF
--- a/host_vars/vagrant.yml
+++ b/host_vars/vagrant.yml
@@ -28,7 +28,9 @@ iptables:
 
 # mosquitto configuration
 mosquitto:
-  fqdn: localhost
+  # the full domain by which the MQTT broker is reachable
+  # e.g. subdomain.example.com
+  fqdn: subdomain.example.com
   letsencrypt:
     email: info@example.com
     accept_letsencrypt_tos: False

--- a/host_vars/vagrant.yml
+++ b/host_vars/vagrant.yml
@@ -28,6 +28,10 @@ iptables:
 
 # mosquitto configuration
 mosquitto:
+  fqdn: localhost
+  letsencrypt:
+    email: info@example.com
+    accept_letsencrypt_tos: False
   listeners:
     -
       bind_address: 0.0.0.0


### PR DESCRIPTION
fixes the following error:
`TASK [mosquitto : copy mosquitto configuration] ********************************
fatal: [vagrant]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'letsencrypt'"}`